### PR TITLE
Cast u128 into strings to avoid rounding issues

### DIFF
--- a/backend/src/api/endpoints.rs
+++ b/backend/src/api/endpoints.rs
@@ -65,7 +65,7 @@ pub struct GetAllocationAmountParams {
 #[utoipa::path(
     tag = "Gets the allocated, accumulated amount for a given address",
     responses(
-        (status = 200, description= "The allocated amount in hex", body = u128),       
+        (status = 200, description= "The allocated amount", body = String),       
     ),
     params(
         GetAllocationAmountParams
@@ -77,7 +77,7 @@ pub async fn get_allocation_amount(query: web::Query<GetAllocationAmountParams>)
     let round = if query.round == Some(0) { None } else { query.round };
     
     match get_raw_allocation_amount(round, &query.address.to_lowercase()) {
-        Ok(value) => HttpResponse::Ok().json(value),
+        Ok(value) => HttpResponse::Ok().json(value.to_string()),
         Err(value) => HttpResponse::BadRequest().json(value)
     }
 }

--- a/backend/src/api/processor.rs
+++ b/backend/src/api/processor.rs
@@ -55,8 +55,8 @@ pub fn get_raw_root(round: Option<u8>) -> Result<RootQueryResult, String> {
     };
     let res = RootQueryResult {
         root: felt_to_b16(&relevant_data.tree.root.value),
-        accumulated_total_amount: relevant_data.accumulated_total_amount,
-        round_total_amount: relevant_data.round_total_amount,
+        accumulated_total_amount: relevant_data.accumulated_total_amount.to_string(),
+        round_total_amount: relevant_data.round_total_amount.to_string(),
     };
     Ok(res)
 }

--- a/backend/src/api/structs.rs
+++ b/backend/src/api/structs.rs
@@ -51,9 +51,9 @@ pub struct RootQueryResult {
     /// The Merkle root for this round
     pub root: String,
     /// The accumulated amount of tokens to be distributed in a round. Includes amounts from all previous rounds
-    pub accumulated_total_amount: u128,
+    pub accumulated_total_amount: String,
     /// The total amount of tokens to be distributed in a round. Includes amounts only from one round
-    pub round_total_amount: u128,
+    pub round_total_amount: String,
 }
 
 /// A node in a Merkle tree


### PR DESCRIPTION
Rust's serde_json crate can't handle u128 (https://github.com/serde-rs/json/issues/846 , tried also "arbitrary_precision" but it fails even worse).

Cast all u128 in the API to strings. This should be ok for frontend integrations since they have the same precision issues: they will need to cast any number first to a string in any case.

Our example frontend doesn't require changes (tested).