### PR TITLE
Fix memory issues

### DIFF
--- a/backend/src/api/data_storage.rs
+++ b/backend/src/api/data_storage.rs
@@ -1,20 +1,15 @@
-use lazy_static::lazy_static;
-use std::sync::RwLock;
-
-use crate::api::structs::RoundTreeData;
-
 use super::processor::read_allocations;
+use crate::api::structs::RoundTreeData;
+use lazy_static::lazy_static;
+use std::sync::{RwLock, RwLockReadGuard};
 
 // Use RwLock to allow for mutable access to the data
 lazy_static! {
     static ref ROUND_DATA: RwLock<Vec<RoundTreeData>> = RwLock::new(Vec::new());
 }
 
-pub fn get_all_data() -> Vec<RoundTreeData> {
-    ROUND_DATA
-        .read()
-        .expect("Failed to acquire read lock")
-        .clone()
+pub fn get_all_data() -> RwLockReadGuard<'static, Vec<RoundTreeData>> {
+    ROUND_DATA.read().expect("Failed to acquire read lock")
 }
 
 pub fn update_api_data() {

--- a/backend/src/api/processor.rs
+++ b/backend/src/api/processor.rs
@@ -75,15 +75,12 @@ fn get_round_data(round: Option<u8>) -> Result<RoundTreeData, String> {
             Some(p) => p.round,
         },
     };
-    let relevant_data: Vec<RoundTreeData> = round_data
-        .iter()
-        .filter(|&p| p.round == use_round)
-        .cloned()
-        .collect();
-    if relevant_data.len() != 1 {
-        return Err("No allocation data available".to_string());
+    let relevant_data = round_data.iter().find(|&p| p.round == use_round);
+
+    match relevant_data {
+        Some(data) => Ok(data.clone()),
+        None => Err("No allocation data available".to_string()),
     }
-    Ok(relevant_data.get(0).unwrap().clone())
 }
 
 /// Converts JSON allocation data into cumulative tree+data per round


### PR DESCRIPTION
- Remove cloning when querying data from "get_all_data". This changes the function signature slightly, but doesn't affect the API
- Similar fix for the underlying call "get_round_data": don't collect a vector (definitely don't clone it) because we only need one entry from it

These changes are inspired by reports from clients and their own fix: https://github.com/10k-swap/10k_swap-seabed/commit/007b0da0d25e8e2f0ec1f1af63e2466002be2638

Unit tests pass, performed also simple tests through the API. But no rigorous manual testing performed, and no memory analysis performed.